### PR TITLE
public enum AuthPolicy.HttpMethod

### DIFF
--- a/blueprints/java/src/io/AuthPolicy.java
+++ b/blueprints/java/src/io/AuthPolicy.java
@@ -217,7 +217,7 @@ public class AuthPolicy {
         }
     }
 
-    enum HttpMethod {
+    public enum HttpMethod {
         GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS, ALL
     }
 


### PR DESCRIPTION
I was running into an issue when trying to access static method of `AuthPolicy.getAllowOnePolicy` and `AuthPolicy.getDenyOnePolicy` using java blueprint.

This publicizes the inner enum on `AuthPolicy`, so we can provide it to the exposed static methods.

With this change I can now call:

```java 
return new AuthPolicy(principalId, AuthPolicy.PolicyDocument.getDenyAllPolicy(region, awsAccountId, restApiId, stage, AuthPolicy.HttpMethod.GET, "some/path"));
```