### PR TITLE
Fix PolicyDocument compile type error

### DIFF
--- a/blueprints/java/src/io/AuthPolicy.java
+++ b/blueprints/java/src/io/AuthPolicy.java
@@ -42,7 +42,7 @@ public class AuthPolicy {
     transient AuthPolicy.PolicyDocument policyDocumentObject;
     Map<String, Object> policyDocument;
 
-    public AuthPolicy(String principalId, PolicyDocument policyDocumentObject) {
+    public AuthPolicy(String principalId, AuthPolicy.PolicyDocument policyDocumentObject) {
         this.principalId = principalId;
         this.policyDocumentObject = policyDocumentObject;
     }


### PR DESCRIPTION
Fixes:

```
[error] /c/Users/Eric Peters/IdeaProjects/ta-apigateway-auth/src/main/java/ta/apigateway/auth/AuthPolicy.java:53:43: not found: type PolicyDocument
[error]     public AuthPolicy(String principalId, PolicyDocument policyDocumentObject) {
[error]
```