### PR TITLE
Add Rust blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Also available in the Lambda console, the Python blueprint includes the AuthPoli
 ## Go
 Not available in the Lambda console. Use the AuthorizerResponse object to generate IAM policies for your custom authorizer. See comments for more details.
 
+## Rust
+Not available in the Lambda console. Using `awslabs/aws-lambda-rust-runtime`. Use the APIGatewayPolicyBuilder object to generate IAM policies for your custom authorizer. See comments for more details.
+
 ## Docs ##
 For more details, see public documentation for:
 - API Gateway Custom Authorizers -- [Blog Post](https://aws.amazon.com/blogs/compute/introducing-custom-authorizers-in-amazon-api-gateway/) -- [Developer Guide](http://docs.aws.amazon.com/apigateway/latest/developerguide/use-custom-authorizer.html)

--- a/blueprints/rust/main.rs
+++ b/blueprints/rust/main.rs
@@ -1,0 +1,212 @@
+#![allow(dead_code)]
+#[macro_use]
+extern crate lambda_runtime as lambda;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate log;
+extern crate simple_logger;
+
+use lambda::error::HandlerError;
+
+use serde_json::json;
+use std::error::Error;
+
+static POLICY_VERSION: &str = "2012-10-17"; // override if necessary
+
+fn my_handler(
+    event: APIGatewayCustomAuthorizerRequest,
+    _ctx: lambda::Context,
+) -> Result<APIGatewayCustomAuthorizerResponse, HandlerError> {
+    info!("Client token: {}", event.authorization_token);
+    info!("Method ARN: {}", event.method_arn);
+
+    // validate the incoming token
+    // and produce the principal user identifier associated with the token
+
+    // this could be accomplished in a number of ways:
+    // 1. Call out to OAuth provider
+    // 2. Decode a JWT token inline
+    // 3. Lookup in a self-managed DB
+    let principal_id = "user|a1b2c3d4";
+
+    // you can send a 401 Unauthorized response to the client by failing like so:
+    // Err(HandlerError{ msg: "Unauthorized".to_string(), backtrace: None });
+
+    // if the token is valid, a policy must be generated which will allow or deny access to the client
+
+    // if access is denied, the client will recieve a 403 Access Denied response
+    // if access is allowed, API Gateway will proceed with the backend integration configured on the method that was called
+
+    // this function must generate a policy that is associated with the recognized principal user identifier.
+    // depending on your use case, you might store policies in a DB, or generate them on the fly
+
+    // keep in mind, the policy is cached for 5 minutes by default (TTL is configurable in the authorizer)
+    // and will apply to subsequent calls to any method/resource in the RestApi
+    // made with the same token
+
+    //the example policy below denies access to all resources in the RestApi
+    let tmp: Vec<&str> = event.method_arn.split(":").collect();
+    let api_gateway_arn_tmp: Vec<&str> = tmp[5].split("/").collect();
+    let aws_account_id = tmp[4];
+    let region = tmp[3];
+    let rest_api_id = api_gateway_arn_tmp[0];
+    let stage = api_gateway_arn_tmp[1];
+
+    let policy = APIGatewayPolicyBuilder::new(region, aws_account_id, rest_api_id, stage)
+        .deny_all_methods()
+        .build();
+
+    // new! -- add additional key-value pairs associated with the authenticated principal
+    // these are made available by APIGW like so: $context.authorizer.<key>
+    // additional context is cached
+    Ok(APIGatewayCustomAuthorizerResponse {
+        principal_id: principal_id.to_string(),
+        policy_document: policy,
+        context: json!({
+        "stringKey": "stringval",
+        "numberKey": 123,
+        "booleanKey": true
+        }),
+    })
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    simple_logger::init_with_level(log::Level::Info)?;
+    lambda!(my_handler);
+
+    Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct APIGatewayCustomAuthorizerRequest {
+    #[serde(rename = "type")]
+    _type: String,
+    authorization_token: String,
+    method_arn: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[allow(non_snake_case)]
+struct APIGatewayCustomAuthorizerPolicy {
+    Version: String,
+    Statement: Vec<IAMPolicyStatement>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct APIGatewayCustomAuthorizerResponse {
+    principal_id: String,
+    policy_document: APIGatewayCustomAuthorizerPolicy,
+    context: serde_json::Value,
+}
+
+#[derive(Serialize, Deserialize)]
+#[allow(non_snake_case)]
+struct IAMPolicyStatement {
+    Action: Vec<String>,
+    Effect: Effect,
+    Resource: Vec<String>,
+}
+
+struct APIGatewayPolicyBuilder {
+    region: String,
+    aws_account_id: String,
+    rest_api_id: String,
+    stage: String,
+    policy: APIGatewayCustomAuthorizerPolicy,
+}
+
+#[derive(Serialize, Deserialize)]
+enum Method {
+    #[serde(rename = "GET")]
+    Get,
+    #[serde(rename = "POST")]
+    Post,
+    #[serde(rename = "*PUT")]
+    Put,
+    #[serde(rename = "DELETE")]
+    Delete,
+    #[serde(rename = "PATCH")]
+    Patch,
+    #[serde(rename = "HEAD")]
+    Head,
+    #[serde(rename = "OPTIONS")]
+    Options,
+    #[serde(rename = "*")]
+    All,
+}
+
+#[derive(Serialize, Deserialize)]
+enum Effect {
+    Allow,
+    Deny,
+}
+
+impl APIGatewayPolicyBuilder {
+    pub fn new(
+        region: &str,
+        account_id: &str,
+        api_id: &str,
+        stage: &str,
+    ) -> APIGatewayPolicyBuilder {
+        Self {
+            region: region.to_string(),
+            aws_account_id: account_id.to_string(),
+            rest_api_id: api_id.to_string(),
+            stage: stage.to_string(),
+            policy: APIGatewayCustomAuthorizerPolicy {
+                Version: POLICY_VERSION.to_string(),
+                Statement: vec![],
+            },
+        }
+    }
+
+    pub fn add_method<T: Into<String>>(
+        mut self,
+        effect: Effect,
+        method: Method,
+        resource: T,
+    ) -> Self {
+        let resource_arn = format!(
+            "arn:aws:execute-api:{}:{}:{}/{}/{}/{}",
+            &self.region,
+            &self.aws_account_id,
+            &self.rest_api_id,
+            &self.stage,
+            serde_json::to_string(&method).unwrap(),
+            resource.into().trim_start_matches("/")
+        );
+
+        let stmt = IAMPolicyStatement {
+            Effect: effect,
+            Action: vec!["execute-api:Invoke".to_string()],
+            Resource: vec![resource_arn],
+        };
+
+        self.policy.Statement.push(stmt);
+        self
+    }
+
+    pub fn allow_all_methods(self) -> Self {
+        self.add_method(Effect::Allow, Method::All, "*")
+    }
+
+    pub fn deny_all_methods(self) -> Self {
+        self.add_method(Effect::Deny, Method::All, "*")
+    }
+
+    pub fn allow_method(self, method: Method, resource: String) -> Self {
+        self.add_method(Effect::Allow, method, resource)
+    }
+
+    pub fn deny_method(self, method: Method, resource: String) -> Self {
+        self.add_method(Effect::Deny, method, resource)
+    }
+
+    // Creates and executes a new child thread.
+    pub fn build(self) -> APIGatewayCustomAuthorizerPolicy {
+        self.policy
+    }
+}


### PR DESCRIPTION
Issue #, if available:

❌

Description of changes:
Implemented custom authorizer blueprint similar to the Golang that is already in the repo. I was using official AWS rust runtime. I did not include dependencies in the repo. I could not find any official crate containing request/response events, so I have implemented my own. I have put everything inside one file, but I can split (and refactor) if needed.

To build the policy I used a consuming builder pattern for convenience, that can be changed as well if needed. The goal of code was to illustrate how authorizer can be implemented, I did not put to much attention to performance.
If there is a place where events request/response objects will be implemented for Rust, I would be happy to use them, or even contribute to the project.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.