### PR TITLE
Fix typo in Go example

### DIFF
--- a/blueprints/go/main.go
+++ b/blueprints/go/main.go
@@ -24,7 +24,7 @@ import (
 
 func handleRequest(ctx context.Context, event events.APIGatewayCustomAuthorizerRequest) (events.APIGatewayCustomAuthorizerResponse, error) {
 	// Do not print the auth token unless absolutely necessary
-+	// log.Println("Client token: " + event.AuthorizationToken)
+	// log.Println("Client token: " + event.AuthorizationToken)
 	log.Println("Method ARN: " + event.MethodArn)
 
 	// validate the incoming token


### PR DESCRIPTION
The Golang example did not compile, since there was a plus sign in front a comment. This change fixes that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.