### PR TITLE
Fixed misleading comment about stars in resources, and added link to docs

### DIFF
--- a/blueprints/dotnet/src/APIGatewayAuthorizerHandler/AuthPolicyBuilder.cs
+++ b/blueprints/dotnet/src/APIGatewayAuthorizerHandler/AuthPolicyBuilder.cs
@@ -58,14 +58,20 @@ namespace APIGatewayAuthorizerHandler
         {
             PrincipalId = principalId;
             AwsAccountId = awsAccountId;
-
-            // Replace the placeholder value with a default API Gateway API id, or '*' for all APIs.
+            
+            // Replace the placeholder value with a default API Gateway API id to be used in the policy. 
+            // Beware of using '*' since it will not simply mean any API Gateway API id, because stars will greedily expand over '/' or other separators. 
+            // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
             _restApiId = string.IsNullOrWhiteSpace(apiOptions?.RestApiId) ? "<<restApiId>>" : apiOptions.RestApiId;
 
-            // Replace the placeholder value with a default region where the API is deployed, or '*' for all regions.
+            // Replace the placeholder value with a default region to be used in the policy. 
+            // Beware of using '*' since it will not simply mean any region, because stars will greedily expand over '/' or other separators. 
+            // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
             _region = string.IsNullOrWhiteSpace(apiOptions?.Region) ? "<<region>>" : apiOptions.Region;
 
-            // Replace the placeholder value with a default stage name used in the policy, or '*' for all stages.
+            // Replace the placeholder value with a default stage to be used in the policy. 
+            // Beware of using '*' since it will not simply mean any stage, because stars will greedily expand over '/' or other separators. 
+            // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
             _stage = string.IsNullOrWhiteSpace(apiOptions?.Stage) ? "<<stage>>" : apiOptions.Stage;
         }
 

--- a/blueprints/go/main.go
+++ b/blueprints/go/main.go
@@ -155,10 +155,21 @@ func NewAuthorizerResponse(principalID string, AccountID string) *AuthorizerResp
 				Version: "2012-10-17",
 			},
 		},
-		Region:    "<<region>>", // Replace the placeholder value with the region where the API is deployed, or '*' for all regions.
+		// Replace the placeholder value with a default region to be used in the policy. 
+		// Beware of using '*' since it will not simply mean any region, because stars will greedily expand over '/' or other separators. 
+		// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
+		Region:    "<<region>>", 
 		AccountID: AccountID,
-		APIID:     "<<restApiId>>", // Replace the placeholder value with an API Gateway API id, or '*' for all APIs.
-		Stage:     "<<stage>>", // Replace the placeholder value with the name of the stage used in the policy, or '*' for all stages.
+		
+		// Replace the placeholder value with a default API Gateway API id to be used in the policy. 
+		// Beware of using '*' since it will not simply mean any API Gateway API id, because stars will greedily expand over '/' or other separators. 
+		// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
+		APIID:     "<<restApiId>>", 
+		
+		// Replace the placeholder value with a default stage to be used in the policy. 
+		// Beware of using '*' since it will not simply mean any stage, because stars will greedily expand over '/' or other separators. 
+		// See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
+		Stage:     "<<stage>>", 
 	}
 }
 

--- a/blueprints/nodejs/index.js
+++ b/blueprints/nodejs/index.js
@@ -140,17 +140,26 @@ function AuthPolicy(principal, awsAccountId, apiOptions) {
     this.denyMethods = [];
 
     if (!apiOptions || !apiOptions.restApiId) {
-      this.restApiId = "<<restApiId>>"; // Replace the placeholder value with a default API Gateway API id, or '*' for all APIs.
+    // Replace the placeholder value with a default API Gateway API id to be used in the policy. 
+    // Beware of using '*' since it will not simply mean any API Gateway API id, because stars will greedily expand over '/' or other separators. 
+    // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details.
+      this.restApiId = "<<restApiId>>"; 
     } else {
       this.restApiId = apiOptions.restApiId;
     }
     if (!apiOptions || !apiOptions.region) {
-      this.region = "<<region>>"; // Replace the placeholder value with a default region where the API is deployed, or '*' for all regions.
+    // Replace the placeholder value with a default region to be used in the policy. 
+    // Beware of using '*' since it will not simply mean any region, because stars will greedily expand over '/' or other separators. 
+    // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
+      this.region = "<<region>>";
     } else {
       this.region = apiOptions.region;
     }
     if (!apiOptions || !apiOptions.stage) {
-      this.stage = "<<stage>>"; // Replace the placeholder value with a default stage name used in the policy, or '*' for all stages.
+    // Replace the placeholder value with a default stage to be used in the policy. 
+    // Beware of using '*' since it will not simply mean any stage, because stars will greedily expand over '/' or other separators. 
+    // See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. 
+      this.stage = "<<stage>>";
     } else {
       this.stage = apiOptions.stage;
     }

--- a/blueprints/python/api-gateway-authorizer-python.py
+++ b/blueprints/python/api-gateway-authorizer-python.py
@@ -100,11 +100,19 @@ class AuthPolicy(object):
 
     
     restApiId = "<<restApiId>>"
-    """Replace the placeholder value with an API Gateway API id, or '*' for all APIs."""
+    """ Replace the placeholder value with a default API Gateway API id to be used in the policy. 
+    Beware of using '*' since it will not simply mean any API Gateway API id, because stars will greedily expand over '/' or other separators. 
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. """    
+
     region = "<<region>>"
-    """Replace the placeholder value with the region where the API is deployed, or '*' for all regions."""
+    """ Replace the placeholder value with a default region to be used in the policy. 
+    Beware of using '*' since it will not simply mean any region, because stars will greedily expand over '/' or other separators. 
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. """    
+
     stage = "<<stage>>"
-    """Replace the placeholder value with the name of the stage used in the policy, or '*' for all stages."""
+    """ Replace the placeholder value with a default stage to be used in the policy. 
+    Beware of using '*' since it will not simply mean any stage, because stars will greedily expand over '/' or other separators. 
+    See https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html for more details. """
 
     def __init__(self, principal, awsAccountId):
         self.awsAccountId = awsAccountId


### PR DESCRIPTION
Fixed misleading comment about stars in resources stating that they could mean any stage, apiId, or region.
Actually '*' expands over '/' so it goes beyond the limiter of stage, apiId, or region. It can cause confusion for developers.
Added a reference to documentation, that was recently updated, giving more details.

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_resource.html

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
